### PR TITLE
Fix BG2Img to make it work with Advance 3

### DIFF
--- a/BG2Img/Program.cs
+++ b/BG2Img/Program.cs
@@ -67,7 +67,7 @@ namespace BG2Img
 				if (bg1 != null)
 					BackgroundToImage(bg1, palette, lvinf.Background1);
 				if (bg2 != null)
-					BackgroundToImage(bg1, palette, lvinf.Background1);
+					BackgroundToImage(bg2, palette, lvinf.Background2);
 				palette[0] = Color.Transparent;
 				if (fghigh != null)
 					ForegroundToImage(fghigh, palette, lvinf.ForegroundHigh, proj.Game);


### PR DESCRIPTION
If you use BG2Img after extracting data from Advance 3, the second BG layer won't extract.
This pull request aims to fix the bug to allow for full compatibility with Advance 3